### PR TITLE
Updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsdoc-babel",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A JSDoc plugin that transforms ES6 source files with Babel before they are processsed.",
   "main": "index.js",
   "scripts": {
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/ctumolosus/jsdoc-babel",
   "dependencies": {
-    "babel-core": "^5.6.15",
-    "lodash": "^3.9.3"
+    "babel-core": "^6.9.0",
+    "lodash": "^4.13.1"
   }
 }


### PR DESCRIPTION
I think the dependencies of this package should be updated, especially Babel, which changed quite a bit from Babel 5 to Babel 6. As far as I can tell, the only required change is to update the version numbers in `package.json`.