### PR TITLE
Move dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/ctumolosus/jsdoc-babel/issues"
   },
   "homepage": "https://github.com/ctumolosus/jsdoc-babel",
-  "dependencies": {
+  "peerDependencies": {
     "babel-core": "^6.9.0",
     "lodash": "^4.13.1"
   },


### PR DESCRIPTION
This changes reduces the dependency on jsdoc-babel from being 6MB and 2.8k files to 0MB and <10 files. 

It is a reasonable assumption that if someone wants to use babel in jsdoc, they are using it elsewhere in their project and would like the versions to be exactly the same.

lodash is used by [babel itself](https://github.com/babel/babel/blob/master/package.json#L31) and likely most projects using babel, but this is a less clear cut choice. If you think it's better to leave lodash as a dependency, I would be happy to create PR that moves it to be just the the 5 functions (assign, includes, get, last, omit) [more precisely](https://www.npmjs.com/browse/keyword/lodash-modularized). 

See: https://docs.npmjs.com/files/package.json#peerdependencies and https://nodejs.org/en/blog/npm/peer-dependencies/