### PR TITLE
Move babel-core to peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,14 @@
   },
   "homepage": "https://github.com/ctumolosus/jsdoc-babel",
   "dependencies": {
-    "babel-core": "^6.9.0",
     "lodash": "^4.13.1"
+  },
+  "peerDependencies": {
+    "babel-core": ">6.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",
+    "babel-core": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-2": "^6.5.0",
     "chai": "^3.5.0",


### PR DESCRIPTION
Move babel core to peer as it should be assumed the use already has this installed.