### PR TITLE
added code to preserve the line numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,4 @@ Thumbs.db
 
 # Generated files #
 ###################
-lib
 example/docs

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,80 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.handlers = undefined;
+
+var _lodash = require('lodash');
+
+var _babelCore = require('babel-core');
+
+var _jsdocRegex = require('jsdoc-regex');
+
+var _jsdocRegex2 = _interopRequireDefault(_jsdocRegex);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var defaults = { extensions: ['js'] };
+
+function shouldProcessFile(filename, _ref) {
+  var extensions = _ref.extensions;
+
+  return (0, _lodash.includes)(extensions, (0, _lodash.last)(filename.split('.')));
+}
+
+function countCharInRange(source, from, to, char) {
+  var cnt = 0;
+  for (var i = from; i < to; i += 1) {
+    if (source[i] === char) {
+      cnt += 1;
+    }
+  }
+  return cnt;
+}
+
+function stripWhitespace(text) {
+  return text.replace(/ /g, '');
+}
+
+function processFile(source, options, doclets) {
+  var regex = (0, _jsdocRegex2.default)();
+  var lastIndex = 0;
+  var linesCount = 1;
+  var match = regex.exec(source);
+  while (match !== null) {
+    var _match = match,
+        index = _match.index;
+
+    linesCount += countCharInRange(source, lastIndex, index, '\n');
+    var key = stripWhitespace(match[0]);
+    // eslint-disable-next-line no-param-reassign
+    doclets[key] = linesCount;
+    lastIndex = index;
+    match = regex.exec(source);
+  }
+  return (0, _babelCore.transform)(source, (0, _lodash.omit)(options, 'extensions')).code;
+}
+
+var doclets = {};
+// eslint-disable-next-line import/prefer-default-export
+var handlers = exports.handlers = {
+  beforeParse: function beforeParse(event) {
+    doclets = {};
+    var options = (0, _lodash.assign)(defaults, {
+      filename: event.filename
+    }, (0, _lodash.get)(global, 'env.conf.babel'));
+
+    if (shouldProcessFile(event.filename, options)) {
+      // eslint-disable-next-line no-param-reassign
+      event.source = processFile(event.source, options, doclets);
+    }
+  },
+  newDoclet: function newDoclet(e) {
+    if (e) {
+      if (doclets[stripWhitespace(e.doclet.comment)]) {
+        e.doclet.meta.lineno = doclets[stripWhitespace(e.doclet.comment)];
+      }
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "src"
   ],
   "scripts": {
+    "prepare": "babel src --out-dir lib",
     "build": "babel src --out-dir lib",
     "lint": "eslint src test",
     "prebuild": "npm run test",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jsdoc-babel",
   "version": "0.3.0",
   "description": "A JSDoc plugin that transforms ES6 source files with Babel before they are processsed.",
-  "main": "src/index.js",
+  "main": "lib/index.js",
   "files": [
     "lib",
     "src"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/ctumolosus/jsdoc-babel",
   "dependencies": {
+    "jsdoc-regex": "^1.0.1",
     "lodash": "^4.13.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jsdoc-babel",
   "version": "0.3.0",
   "description": "A JSDoc plugin that transforms ES6 source files with Babel before they are processsed.",
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "files": [
     "lib",
     "src"

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,6 @@ export const handlers = {
       // eslint-disable-next-line no-param-reassign
       event.source = processFile(event.source, options, doclets);
     }
-    console.log(doclets);
   },
   newDoclet: (e) => {
     if (e) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import { assign, includes, get, last, omit } from 'lodash';
 import { transform } from 'babel-core';
+import jsdocRegex from 'jsdoc-regex';
 
 const defaults = { extensions: ['js'] };
 
@@ -7,20 +8,57 @@ function shouldProcessFile(filename, { extensions }) {
   return includes(extensions, last(filename.split('.')));
 }
 
-function processFile(source, options) {
+function countCharInRange(source, from, to, char) {
+  let cnt = 0;
+  for (let i = from; i < to; i += 1) {
+    if (source[i] === char) {
+      cnt += 1;
+    }
+  }
+  return cnt;
+}
+
+function stripWhitespace(text) {
+  return text.replace(/ /g, '');
+}
+
+function processFile(source, options, doclets) {
+  const regex = jsdocRegex();
+  let lastIndex = 0;
+  let linesCount = 1;
+  let match = regex.exec(source);
+  while (match !== null) {
+    const { index } = match;
+    linesCount += countCharInRange(source, lastIndex, index, '\n');
+    const key = stripWhitespace(match[0]);
+    // eslint-disable-next-line no-param-reassign
+    doclets[key] = linesCount;
+    lastIndex = index;
+    match = regex.exec(source);
+  }
   return transform(source, omit(options, 'extensions')).code;
 }
 
+let doclets = {};
 // eslint-disable-next-line import/prefer-default-export
 export const handlers = {
   beforeParse: (event) => {
+    doclets = {};
     const options = assign(defaults, {
       filename: event.filename,
     }, get(global, 'env.conf.babel'));
 
     if (shouldProcessFile(event.filename, options)) {
       // eslint-disable-next-line no-param-reassign
-      event.source = processFile(event.source, options);
+      event.source = processFile(event.source, options, doclets);
+    }
+    console.log(doclets);
+  },
+  newDoclet: (e) => {
+    if (e) {
+      if (doclets[stripWhitespace(e.doclet.comment)]) {
+        e.doclet.meta.lineno = doclets[stripWhitespace(e.doclet.comment)];
+      }
     }
   },
 };


### PR DESCRIPTION
The code tracks the comment locations from before babel and restores them after jsdoc was run